### PR TITLE
feat(async)!: migrate to a new simplier/easier async module!

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -29,18 +29,6 @@ jobs:
           token: ${{ secrets.GITHUB_TOKEN }}
           version: latest
           args: --config-path .stylua.toml ./lua ./spec
-      - name: Add async.lua
-        if: ${{ github.ref != 'refs/heads/main' }}
-        run: |
-          echo "pwd"
-          echo $PWD
-          git clone --depth=1 https://github.com/lewis6991/async.nvim.git ~/.async.nvim
-          echo 'ls -lh'
-          ls -lh
-          rm -rf ./lua/commons/async.lua
-          cp -rf ~/.async.nvim/lua/async.lua ./lua/commons/async.lua
-          rm -rf ~/.async.nvim
-          sed -i '1 i\---@diagnostic disable' ./lua/commons/async.lua
       - name: Add color.hsl.lua
         if: ${{ github.ref != 'refs/heads/main' }}
         run: |

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -58,8 +58,6 @@ jobs:
           push_options: "--force"
   unit_test:
     name: Unxi Test
-    needs:
-      - lint
     strategy:
       matrix:
         include:

--- a/README.md
+++ b/README.md
@@ -28,7 +28,6 @@ Please check [documentation](https://linrongbin16.github.io/commons.nvim) for mo
 
 ## Embedded Libraries
 
-- [async.nvim](https://github.com/lewis6991/async.nvim): Small async library for Neovim plugins.
 - [colors.lua](http://sputnik.freewisdom.org/lib/colors/): HSL Color Theory Computation in Lua.
 
 ## Contribute

--- a/docs/README.md
+++ b/docs/README.md
@@ -13,7 +13,7 @@ The commons lua library for Neovim plugin project.
 
 ## Modules
 
-- [commons.async](/commons_async.md): Embedded [lewis6991/async.nvim](https://github.com/lewis6991/async.nvim) library.
+- [commons.async](/commons_async.md): Very simple and rough wrap to turn callback-style functions into async-style functions, with the help of lua's `coroutine`, thus getting out of the callback hell.
 - commons.color
   - [commons.color.hl](/commons_color_hl.md): RGB color & nvim syntax highlight utilities.
   - [commons.color.hsl](/commons_color_hsl.md): Embedded [sputnik's colors](http://sputnik.freewisdom.org/lib/colors/) library.

--- a/docs/README.md
+++ b/docs/README.md
@@ -13,7 +13,7 @@ The commons lua library for Neovim plugin project.
 
 ## Modules
 
-- [commons.async](/commons_async.md): Very simple and rough wrap to turn callback-style functions into async-style functions, with the help of lua's `coroutine`, thus getting out of the callback hell.
+- [commons.async](/commons_async.md): Very simple wrapper to turn callback-style functions into async-style functions, with the help of lua's `coroutine`, thus getting out of the callback hell.
 - commons.color
   - [commons.color.hl](/commons_color_hl.md): RGB color & nvim syntax highlight utilities.
   - [commons.color.hsl](/commons_color_hsl.md): Embedded [sputnik's colors](http://sputnik.freewisdom.org/lib/colors/) library.

--- a/docs/commons_async.md
+++ b/docs/commons_async.md
@@ -1,3 +1,147 @@
 # [commons.async](https://github.com/linrongbin16/commons.nvim/blob/main/lua/commons/async.lua)
 
-Embedded [lewis6991/async.nvim](https://github.com/lewis6991/async.nvim) library, please refer to the library's documentation.
+Very simple and rough wrap to turn async functions (with callbacks) into coroutine-version functions, thus getting out of the hell of callbacks.
+
+> It is quite simple and rough, but correctly works. Big and complete coroutine library requires a lot of maintain effort (and I am not a master of lua coroutine), simple and easy is good enough.
+
+## Functions
+
+### `wrap`
+
+Wrap a async function (with a callback in the last parameter), into a coroutine-version function without callbacks. Note: you can use the coroutine-version function without callbacks (just like a sync function)!
+
+!> The callback parameter must be the last parameter in the async function!
+
+```lua
+--- @param func function
+--- @param argc integer
+--- @return function
+M.wrap = function(func, argc)
+```
+
+#### Parameters
+
+- `func`: Async function with a callback parameter (as the last parameter).
+- `argc`: Parameters number of the async function `func`.
+
+#### Returns
+
+It returns the wrapped coroutine-version function.
+
+### `void`
+
+Creates a async context thus can run coroutine-version functions inside it. The async context itself can be invoked in normal sync context, i.e. the Neovim lua scripts.
+
+```lua
+--- @param func function
+--- @return function
+M.void = function(func)
+```
+
+#### Parameters
+
+- `func`: Wrapped coroutine-version function.
+
+#### Returns
+
+It returns the async context, which is also a lua function that can be invoked in normal sync context.
+
+### `schedule`
+
+Schedules Neovim event loop between libuv and `vim` APIs.
+
+```lua
+M.schedule = function()
+```
+
+### Examples
+
+If without the `async` module, when we call the `uv.spawn` API to run some command lines in async way, for example let's echo some messages (`foo`, `bar`, `baz`), we will have to write code like this:
+
+```lua
+local function run_job(cmd, args, callback)
+  local handle
+  handle = vim.uv.spawn(cmd, { args  = args, },
+    function(code)
+      s.handle:close()
+      callback(code)
+    end
+  )
+end
+
+run_job('echo', {'foo'},
+  function(code1)
+    if code1 ~= 0 then
+      return
+    end
+    run_job('echo', {'bar'},
+      function(code2)
+        if code2 ~= 0 then
+          return
+        end
+        run_job('echo', {'baz'})
+      end
+    )
+  end
+)
+```
+
+This easily leads code logics into the hell of callbacks.
+
+The `wrap` API turns async function (with callbacks) into coroutine-version function, so we could use them just like sync functions:
+
+```lua
+local a = require('commons.async')
+
+-- Note:
+-- The 1st parameter `run_job` is the original async function.
+-- The 2nd parameter `3` is the number of the parameters of `run_job` function.
+local run_job_a = a.wrap(run_job, 3)
+```
+
+The wrapped coroutine-version functions must be invoked inside the async context, here comes the `void` API:
+
+```lua
+-- Creates the async context, so `run_job_a` methods can be invoked inside it.
+local run = a.void(function()
+    local code1 = run_job_a('echo', {'foo'})
+    if code1 ~= 0 then
+        return
+    end
+    local code2 = run_job_a('echo', {'bar'})
+    if code2 ~= 0 then
+        return
+    end
+    run_job_a('echo', {'baz'})
+end)
+
+-- Runs the async context in the normal sync context.
+run()
+```
+
+The `void` API creates a async context `run`, thus coroutine-version functions such as `run_job_a` can be invoked inside it just like normal sync functions! And `run` can be directly invoked in normal sync context.
+
+In a real-world Neovim plugin project, the logic inside a async context can be quite completed and developer usually will have to invoke `vim` APIs. There's a technical limitation that we cannot invoke `vim` APIs inside a libuv event loop. Here comes the `schedule` API:
+
+```lua
+local run = a.void(function()
+    local code1 = run_job_a('echo', {'foo'})
+    if code1 ~= 0 then
+        return
+    end
+
+    -- Note: Must call `schedule` before any `vim` APIs.
+    a.schedule()
+
+    -- Then you can call `vim` APIs.
+    local win_height = vim.api.nvim_win_get_height(0)
+
+    local code2 = run_job_a('echo', {'bar'})
+    if code2 ~= 0 then
+        return
+    end
+    run_job_a('echo', {'baz'})
+end)
+
+run()
+```

--- a/docs/commons_async.md
+++ b/docs/commons_async.md
@@ -1,6 +1,6 @@
 # [commons.async](https://github.com/linrongbin16/commons.nvim/blob/main/lua/commons/async.lua)
 
-Very simple and rough wrap to turn callback-style functions into async-style functions, with the help of lua's `coroutine`, thus getting out of the callback hell.
+Very simple wrapper to turn callback-style functions into async-style functions, with the help of lua's `coroutine`, thus getting out of the callback hell.
 
 > It is quite simple and rough, but correctly works. Big and complete coroutine library requires a lot of maintain effort (and I am not a master of lua coroutine), simple and easy is good enough.
 

--- a/docs/commons_async.md
+++ b/docs/commons_async.md
@@ -1,6 +1,6 @@
 # [commons.async](https://github.com/linrongbin16/commons.nvim/blob/main/lua/commons/async.lua)
 
-Very simple and rough wrap to turn async functions (with callbacks) into coroutine-version functions, thus getting out of the hell of callbacks.
+Very simple and rough wrap to turn callback-style functions into async-style functions, with the help of lua's `coroutine`, thus getting out of the callback hell.
 
 > It is quite simple and rough, but correctly works. Big and complete coroutine library requires a lot of maintain effort (and I am not a master of lua coroutine), simple and easy is good enough.
 
@@ -8,9 +8,9 @@ Very simple and rough wrap to turn async functions (with callbacks) into corouti
 
 ### `wrap`
 
-Wrap a async function (with a callback in the last parameter), into a coroutine-version function without callbacks. Note: you can use the coroutine-version function without callbacks (just like a sync function)!
+Wrap a callback-style function, into a async-style function without callbacks. Note: you can use the async-style function without callbacks (just like a sync function)!
 
-!> The callback parameter must be the last parameter in the async function!
+!> The callback parameter must be the last parameter in the callback-style function!
 
 ```lua
 --- @param func function
@@ -21,16 +21,16 @@ M.wrap = function(func, argc)
 
 #### Parameters
 
-- `func`: Async function with a callback parameter (as the last parameter).
-- `argc`: Parameters number of the async function `func`.
+- `func`: The callback-style function with a callback parameter (as the last parameter).
+- `argc`: Parameters number of the function `func`.
 
 #### Returns
 
-It returns the wrapped coroutine-version function.
+It returns the wrapped async-style function.
 
 ### `void`
 
-Creates a async context thus can run coroutine-version functions inside it. The async context itself can be invoked in normal sync context, i.e. the Neovim lua scripts.
+Creates a async context thus can run async-style functions inside it. The async context itself can be called in normal sync context, i.e. the Neovim lua scripts.
 
 ```lua
 --- @param func function
@@ -40,11 +40,11 @@ M.void = function(func)
 
 #### Parameters
 
-- `func`: Wrapped coroutine-version function.
+- `func`: Wrapped async-style function.
 
 #### Returns
 
-It returns the async context, which is also a lua function that can be invoked in normal sync context.
+It returns the async context, which is also a lua function that can be called in normal sync context.
 
 ### `schedule`
 
@@ -56,7 +56,7 @@ M.schedule = function()
 
 ### Examples
 
-If without the `async` module, when we call the `uv.spawn` API to run some command lines in async way, for example let's echo some messages (`foo`, `bar`, `baz`), we will have to write code like this:
+The `libuv` brings a bunch of callback-style functions to turn sync/blocking IO operations into async/non-blocking. It has great performance, while it also brings the callback hell. Consider we are calling the `uv.spawn` API to execute shell commands, for example, let's print some messages with `echo foo`, `echo bar`, `echo baz`, we will have to write code like this:
 
 ```lua
 local function run_job(cmd, args, callback)
@@ -86,23 +86,25 @@ run_job('echo', {'foo'},
 )
 ```
 
-This easily leads code logics into the hell of callbacks.
+This easily leads code logic to callback hell.
 
-The `wrap` API turns async function (with callbacks) into coroutine-version function, so we could use them just like sync functions:
+The `wrap` API turns callback-style function into async-style function, so we could use them just like the `await` functions in javascripts:
 
 ```lua
 local a = require('commons.async')
 
 -- Note:
--- The 1st parameter `run_job` is the original async function.
--- The 2nd parameter `3` is the number of the parameters of `run_job` function.
+-- The 1st parameter `run_job` is the original callback-style function.
+-- The 2nd parameter `3` is the number of the parameters of the function `run_job`.
 local run_job_a = a.wrap(run_job, 3)
 ```
 
-The wrapped coroutine-version functions must be invoked inside the async context, here comes the `void` API:
+The wrapped async-style functions will have exactly the same parameters with the original callback-style function signatures, except the last parameter is been removed. You don't have to pass a callback function to it any longer, the result will be directly returned just like `await` functions in javascripts.
+
+The wrapped async-style functions must be called inside the async context, via the `void` API:
 
 ```lua
--- Creates the async context, so `run_job_a` methods can be invoked inside it.
+-- Creates the async context, so `run_job_a` methods can be called inside it.
 local run = a.void(function()
     local code1 = run_job_a('echo', {'foo'})
     if code1 ~= 0 then
@@ -119,9 +121,11 @@ end)
 run()
 ```
 
-The `void` API creates a async context `run`, thus coroutine-version functions such as `run_job_a` can be invoked inside it just like normal sync functions! And `run` can be directly invoked in normal sync context.
+The `void` API creates a async context `run` (also a lua function), thus the async-style function `run_job_a` can be called inside it, the value passed to the original callback will be directly returned! And `run` can be directly called in the normal Neovim scripts, i.e. a sync context.
 
-In a real-world Neovim plugin project, the logic inside a async context can be quite completed and developer usually will have to invoke `vim` APIs. There's a technical limitation that we cannot invoke `vim` APIs inside a libuv event loop. Here comes the `schedule` API:
+In a real-world Neovim plugin, the code logic of a async context can be quite complicated and developer usually will have to call Neovim APIs (i.e. the `vim.api`, `vim.fn`, `vim.cmd`, etc). There's a technical limitation that we cannot call these `vim` APIs inside a libuv event loop.
+
+We will have to call the `schedule` API before any `vim` APIs:
 
 ```lua
 local run = a.void(function()

--- a/lua/commons/async.lua
+++ b/lua/commons/async.lua
@@ -1,189 +1,88 @@
----@diagnostic disable
---- Small async library for Neovim plugins
+-- Copied from: <https://github.com/neovim/neovim/issues/19624#issuecomment-1202405058>
 
-local function validate_callback(func, callback)
-  if callback and type(callback) ~= 'function' then
-    local info = debug.getinfo(func, 'nS')
-    error(
-      string.format(
-        'Callback is not a function for %s, got: %s',
-        info.short_src .. ':' .. info.linedefined,
-        vim.inspect(callback)
-      )
-    )
-  end
+local co = coroutine
+
+local async_thread = {
+   threads = {},
+}
+
+local function threadtostring(x)
+   if jit then
+      return string.format('%p', x)
+   else
+      return tostring(x):match('thread: (.*)')
+   end
 end
 
--- Coroutine.running() was changed between Lua 5.1 and 5.2:
--- - 5.1: Returns the running coroutine, or nil when called by the main thread.
--- - 5.2: Returns the running coroutine plus a boolean, true when the running
---   coroutine is the main one.
---
--- For LuaJIT, 5.2 behaviour is enabled with LUAJIT_ENABLE_LUA52COMPAT
---
--- We need to handle both.
-local _main_co_or_nil = coroutine.running()
+function async_thread.running()
+   local thread = co.running()
+   local id = threadtostring(thread)
+   return async_thread.threads[id]
+end
 
---- Executes a future with a callback when it is done
---- @param func function
---- @param callback function?
---- @param ... any
-local function run(func, callback, ...)
-  validate_callback(func, callback)
+function async_thread.create(fn)
+   local thread = co.create(fn)
+   local id = threadtostring(thread)
+   async_thread.threads[id] = true
+   return thread
+end
 
-  local co = coroutine.create(func)
+function async_thread.finished(x)
+   if co.status(x) == 'dead' then
+      local id = threadtostring(x)
+      async_thread.threads[id] = nil
+      return true
+   end
+   return false
+end
 
-  local function step(...)
-    local ret = { coroutine.resume(co, ...) }
-    local stat = ret[1]
+local function execute(async_fn, ...)
+   local thread = async_thread.create(async_fn)
 
-    if not stat then
-      local err = ret[2] --[[@as string]]
-      error(
-        string.format('The coroutine failed with this message: %s\n%s', err, debug.traceback(co))
-      )
-    end
+   local function step(...)
+      local ret = { co.resume(thread, ...) }
+      local stat, err_or_fn, nargs = unpack(ret)
 
-    if coroutine.status(co) == 'dead' then
-      if callback then
-        callback(unpack(ret, 2, table.maxn(ret)))
+      if not stat then
+         error(string.format("The coroutine failed with this message: %s\n%s",
+         err_or_fn, debug.traceback(thread)))
       end
-      return
-    end
 
-    --- @type integer, fun(...: any): any
-    local nargs, fn = ret[2], ret[3]
-    assert(type(fn) == 'function', 'type error :: expected func')
+      if async_thread.finished(thread) then
+         return
+      end
 
-    --- @type any[]
-    local args = { unpack(ret, 4, table.maxn(ret)) }
-    args[nargs] = step
-    fn(unpack(args, 1, nargs))
-  end
+      assert(type(err_or_fn) == "function", "type error :: expected func")
 
-  step(...)
+      local ret_fn = err_or_fn
+      local args = { select(4, unpack(ret)) }
+      args[nargs] = step
+      ret_fn(unpack(args, 1, nargs))
+   end
+
+   step(...)
 end
 
 local M = {}
 
----Use this to create a function which executes in an async context but
----called from a non-async context. Inherently this cannot return anything
----since it is non-blocking
---- @generic F: function
---- @param argc integer
---- @param func async F
---- @return F
-function M.sync(argc, func)
-  return function(...)
-    assert(not coroutine.running())
-    local callback = select(argc + 1, ...)
-    run(func, callback, unpack({ ... }, 1, argc))
-  end
-end
-
---- @param argc integer
---- @param func function
---- @param ... any
---- @return any ...
-function M.wait(argc, func, ...)
-  -- Always run the wrapped functions in xpcall and re-raise the error in the
-  -- coroutine. This makes pcall work as normal.
-  local function pfunc(...)
-    local args = { ... } --- @type any[]
-    local cb = args[argc]
-    args[argc] = function(...)
-      cb(true, ...)
-    end
-    xpcall(func, function(err)
-      cb(false, err, debug.traceback())
-    end, unpack(args, 1, argc))
-  end
-
-  local ret = { coroutine.yield(argc, pfunc, ...) }
-
-  local ok = ret[1]
-  if not ok then
-    --- @type string, string
-    local err, traceback = ret[2], ret[3]
-    error(string.format('Wrapped function failed: %s\n%s', err, traceback))
-  end
-
-  return unpack(ret, 2, table.maxn(ret))
-end
-
-function M.run(func, ...)
-  return run(func, nil, ...)
-end
-
---- Creates an async function with a callback style function.
---- @param argc integer
---- @param func function
---- @return function
-function M.wrap(argc, func)
-  assert(type(argc) == 'number')
-  assert(type(func) == 'function')
-  return function(...)
-    return M.wait(argc, func, ...)
-  end
-end
-
---- @generic R
---- @param n integer Mx number of jobs to run concurrently
---- @param thunks (fun(cb: function): R)[]
---- @param interrupt_check fun()?
---- @param callback fun(ret: R[][])
-M.join = M.wrap(4, function(n, thunks, interrupt_check, callback)
-  n = math.min(n, #thunks)
-
-  local ret = {} --- @type any[][]
-
-  if #thunks == 0 then
-    callback(ret)
-    return
-  end
-
-  local remaining = { unpack(thunks, n + 1) }
-  local to_go = #thunks
-
-  local function cb(...)
-    ret[#ret + 1] = { ... }
-    to_go = to_go - 1
-    if to_go == 0 then
-      callback(ret)
-    elseif not interrupt_check or not interrupt_check() then
-      if #remaining > 0 then
-        local next_thunk = table.remove(remaining, 1)
-        next_thunk(cb)
+function M.wrap(func, argc)
+   return function(...)
+      if not async_thread.running() then
+         return func(...)
       end
-    end
-  end
-
-  for i = 1, n do
-    thunks[i](cb)
-  end
-end)
-
----Useful for partially applying arguments to an async function
---- @param fn function
---- @param ... any
---- @return function
-function M.curry(fn, ...)
-  --- @type integer, any[]
-  local nargs, args = select('#', ...), { ... }
-
-  return function(...)
-    local other = { ... }
-    for i = 1, select('#', ...) do
-      args[nargs + i] = other[i]
-    end
-    return fn(unpack(args))
-  end
+      return co.yield(func, argc, ...)
+   end
 end
 
-if vim.schedule then
-  --- An async function that when called will yield to the Neovim scheduler to be
-  --- able to call the API.
-  M.schedule = M.wrap(1, vim.schedule)
+function M.void(func)
+   return function(...)
+      if async_thread.running() then
+         return func(...)
+      end
+      execute(func, ...)
+   end
 end
+
+M.schedule = M.wrap(vim.schedule, 1)
 
 return M

--- a/lua/commons/async.lua
+++ b/lua/commons/async.lua
@@ -36,6 +36,8 @@ function async_thread.finished(x)
    return false
 end
 
+--- @param async_fn function
+--- @param ... any
 local function execute(async_fn, ...)
    local thread = async_thread.create(async_fn)
 
@@ -57,7 +59,7 @@ local function execute(async_fn, ...)
       local ret_fn = err_or_fn
       local args = { select(4, unpack(ret)) }
       args[nargs] = step
-      ret_fn(unpack(args, 1, nargs))
+      ret_fn(unpack(args, 1, nargs --[[@as integer]]))
    end
 
    step(...)
@@ -65,7 +67,10 @@ end
 
 local M = {}
 
-function M.wrap(func, argc)
+--- @param func function
+--- @param argc integer
+--- @return function
+M.wrap = function(func, argc)
    return function(...)
       if not async_thread.running() then
          return func(...)
@@ -74,7 +79,9 @@ function M.wrap(func, argc)
    end
 end
 
-function M.void(func)
+--- @param func function
+--- @return function
+M.void = function(func)
    return function(...)
       if async_thread.running() then
          return func(...)

--- a/lua/commons/async.lua
+++ b/lua/commons/async.lua
@@ -54,7 +54,7 @@ local function execute(async_fn, ...)
          return
       end
 
-      assert(type(err_or_fn) == "function", "type error :: expected func")
+      assert(type(err_or_fn) == "function", "The 1st parameter must be a lua function")
 
       local ret_fn = err_or_fn
       local args = { select(4, unpack(ret)) }

--- a/spec/commons/async_spec.lua
+++ b/spec/commons/async_spec.lua
@@ -21,27 +21,27 @@ describe("commons.async", function()
       local system = async.wrap(vim.system --[[@as function]], 3)
 
       async.void(function()
-        local stdout = ""
+        local stdout_data = ""
         local completed1 = system({ "echo", "foo" }, {
           text = true,
           stdout = function(err, data)
-            stdout = stdout .. data
+            stdout_data = stdout_data .. data
           end,
         })
         print(string.format("async spawn-1 completed:%s", vim.inspect(completed1)))
-        print(string.format("async spawn-1 stdout:%s", vim.inspect(stdout)))
+        print(string.format("async spawn-1 stdout:%s", vim.inspect(stdout_data)))
       end)()
 
       async.void(function()
-        local stdout = ""
+        local stdout_data = ""
         local completed2 = system({ "echo", "foo" }, {
           text = true,
           stdout = function(err, data)
-            stdout = stdout .. data
+            stdout_data = stdout_data .. data
           end,
         })
         print(string.format("async spawn-2 completed:%s", vim.inspect(completed2)))
-        print(string.format("async spawn-2 stdout:%s", vim.inspect(stdout)))
+        print(string.format("async spawn-2 stdout:%s", vim.inspect(stdout_data)))
       end)()
     end)
   end)

--- a/spec/commons/async_spec.lua
+++ b/spec/commons/async_spec.lua
@@ -1,0 +1,48 @@
+local cwd = vim.fn.getcwd()
+
+describe("commons.async", function()
+  local assert_eq = assert.is_equal
+  local assert_true = assert.is_true
+  local assert_false = assert.is_false
+  local assert_truthy = assert.is.truthy
+  local assert_falsy = assert.is.falsy
+
+  before_each(function()
+    vim.api.nvim_command("cd " .. cwd)
+  end)
+
+  local str = require("commons.str")
+  local tbl = require("commons.tbl")
+  local async = require("commons.async")
+  local uv = require("commons.uv")
+
+  describe("[wrap/void]", function()
+    it("wrap", function()
+      local system = async.wrap(vim.system --[[@as function]], 3)
+
+      async.void(function()
+        local stdout = ""
+        local completed1 = system({ "echo", "foo" }, {
+          text = true,
+          stdout = function(err, data)
+            stdout = stdout .. data
+          end,
+        })
+        print(string.format("async spawn-1 completed:%s", vim.inspect(completed1)))
+        print(string.format("async spawn-1 stdout:%s", vim.inspect(stdout)))
+      end)()
+
+      async.void(function()
+        local stdout = ""
+        local completed2 = system({ "echo", "foo" }, {
+          text = true,
+          stdout = function(err, data)
+            stdout = stdout .. data
+          end,
+        })
+        print(string.format("async spawn-2 completed:%s", vim.inspect(completed2)))
+        print(string.format("async spawn-2 stdout:%s", vim.inspect(stdout)))
+      end)()
+    end)
+  end)
+end)

--- a/spec/commons/async_spec.lua
+++ b/spec/commons/async_spec.lua
@@ -25,23 +25,51 @@ describe("commons.async", function()
         local completed1 = system({ "echo", "foo" }, {
           text = true,
           stdout = function(err, data)
-            stdout_data = stdout_data .. data
+            if err then
+              print(
+                string.format(
+                  "async system-1 err:%s, data:%s\n",
+                  vim.inspect(err),
+                  vim.inspect(data)
+                )
+              )
+              return
+            end
+            if type(data) == "string" then
+              stdout_data = stdout_data .. data
+            else
+              print(string.format("async system-1 data (not string):%s\n", vim.inspect(data)))
+            end
           end,
         })
-        print(string.format("async spawn-1 completed:%s", vim.inspect(completed1)))
-        print(string.format("async spawn-1 stdout:%s", vim.inspect(stdout_data)))
+        print(string.format("async system-1 completed:%s\n", vim.inspect(completed1)))
+        print(string.format("async system-1 stdout:%s\n", vim.inspect(stdout_data)))
       end)()
 
       async.void(function()
         local stdout_data = ""
-        local completed2 = system({ "echo", "foo" }, {
+        local completed2 = system({ "echo", "bar" }, {
           text = true,
           stdout = function(err, data)
-            stdout_data = stdout_data .. data
+            if err then
+              print(
+                string.format(
+                  "async system-1 err:%s, data:%s\n",
+                  vim.inspect(err),
+                  vim.inspect(data)
+                )
+              )
+              return
+            end
+            if type(data) == "string" then
+              stdout_data = stdout_data .. data
+            else
+              print(string.format("async system-1 data (not string):%s\n", vim.inspect(data)))
+            end
           end,
         })
-        print(string.format("async spawn-2 completed:%s", vim.inspect(completed2)))
-        print(string.format("async spawn-2 stdout:%s", vim.inspect(stdout_data)))
+        print(string.format("async system-2 completed:%s\n", vim.inspect(completed2)))
+        print(string.format("async system-2 stdout:%s\n", vim.inspect(stdout_data)))
       end)()
     end)
   end)

--- a/vim.toml
+++ b/vim.toml
@@ -1,6 +1,9 @@
 [selene]
 base = "lua51"
 
+[jit]
+any = true
+
 [vim]
 any = true
 
@@ -15,4 +18,3 @@ any = true
 
 [assert]
 any = true
-


### PR DESCRIPTION
There's a break change in lua 5.1/5.2 about `coroutine.running()` API, which could impact the `async` module.

This bug could be reproduced in Fedora 41 workstation edition, see https://github.com/linrongbin16/gitlinker.nvim/issues/257 and https://github.com/linrongbin16/gitlinker.nvim/pull/262.

-------------------

Manually tested here: https://github.com/linrongbin16/gitlinker.nvim/pull/264